### PR TITLE
Fix height calculation bug for platforms under 0.6m in EN14960

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-08-16
+
+### Fixed
+- Fixed TypeError when `calculate_wall_height` is called with platform_height < 0.6m
+  - Method now correctly returns Float 0.0 instead of Integer 0
+  - Added test coverage for the "no walls required" edge case
+
+## [0.4.0] - Previous Release
+
 ### Added
 - Full Sorbet type signatures for all public APIs
 - Runtime type checking with sorbet-runtime

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    en14960 (0.4.0)
+    en14960 (0.4.1)
       sorbet-runtime (~> 0.5)
 
 GEM

--- a/lib/en14960/calculators/slide_calculator.rb
+++ b/lib/en14960/calculators/slide_calculator.rb
@@ -33,7 +33,7 @@ module EN14960
         # highest platform (measured from ground level), with an absolute minimum of 300mm
         # Line 936: If a stop-wall is installed at the runout's end, an additional
         # 50cm must be added to the total runout length
-        return CalculatorResponse.new(value: 0, value_suffix: "m", breakdown: []) if platform_height <= 0
+        return CalculatorResponse.new(value: 0.0, value_suffix: "m", breakdown: []) if platform_height <= 0
 
         # Get constants
         height_ratio = Constants::RUNOUT_CALCULATION_CONSTANTS[:platform_height_ratio]
@@ -113,7 +113,7 @@ module EN14960
       sig { params(platform_height: Float, user_height: Float, has_permanent_roof: T.nilable(T::Boolean)).returns(CalculatorResponse) }
       def calculate_wall_height_requirements(platform_height, user_height, has_permanent_roof = nil)
         # EN 14960-1:2019 Section 4.2.9 (Lines 854-887) - Containment requirements
-        return CalculatorResponse.new(value: 0, value_suffix: "m", breakdown: []) if platform_height <= 0 || user_height <= 0
+        return CalculatorResponse.new(value: 0.0, value_suffix: "m", breakdown: []) if platform_height <= 0 || user_height <= 0
 
         # Get requirement details and breakdown
         requirement_details = get_wall_height_requirement_details(platform_height, user_height, has_permanent_roof)
@@ -261,14 +261,14 @@ module EN14960
 
         case platform_height
         when 0..thresholds[:no_walls_required]
-          0 # No walls required
+          0.0 # No walls required
         when (thresholds[:no_walls_required]..thresholds[:basic_walls])
           user_height # Equal to user height
         when (thresholds[:basic_walls]..thresholds[:enhanced_walls]),
              (thresholds[:enhanced_walls]..thresholds[:max_safe_height])
           (user_height * enhanced_multiplier).round(2) # 1.25× user height
         else
-          0 # Exceeds safe limits
+          0.0 # Exceeds safe limits
         end
       end
     end

--- a/lib/en14960/version.rb
+++ b/lib/en14960/version.rb
@@ -2,5 +2,5 @@
 # typed: strict
 
 module EN14960
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/calculators/slide_calculator_spec.rb
+++ b/spec/calculators/slide_calculator_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe EN14960::Calculators::SlideCalculator do
 
   describe ".calculate_wall_height_requirements" do
     context "platform height ranges (EN 14960-1:2019)" do
+      it "returns 0.0 for platforms under 0.6m (no walls required)" do
+        result = described_class.calculate_wall_height_requirements(0.5, 1.5)
+
+        expect(result.value).to eq(0.0)
+        expect(result.value_suffix).to eq("m")
+        expect(result.breakdown).to include(
+          ["Height range", "Under 0.6m"],
+          ["Requirement", "No containing walls required"]
+        )
+      end
+
       it "requires 1× user height for platforms 0.6m - 3.0m" do
         result = described_class.calculate_wall_height_requirements(2.0, 1.5)
 

--- a/spec/en14960_spec.rb
+++ b/spec/en14960_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe EN14960 do
           ["Height range", "0.6m - 3.0m"]
         )
       end
+
+      it "returns 0.0 (not Integer 0) for platforms under 0.6m" do
+        result = described_class.calculate_wall_height(0.5, 1.5)
+
+        expect(result).to be_a(EN14960::CalculatorResponse)
+        expect(result.value).to eq(0.0)
+        expect(result.value).to be_a(Float)
+        expect(result.breakdown).to include(
+          ["Height range", "Under 0.6m"],
+          ["Requirement", "No containing walls required"]
+        )
+      end
     end
 
     describe ".calculate_user_capacity" do


### PR DESCRIPTION
## Summary
- Fixed a TypeError in `calculate_wall_height` and `calculate_wall_height_requirements` when platform height is less than 0.6m
- Ensured the method returns a Float `0.0` instead of an Integer `0` for no wall requirements
- Added comprehensive test coverage for the edge case where no walls are required
- Updated version to 0.4.1

## Changes

### Core Fixes
- Changed return values from `0` to `0.0` in `slide_calculator.rb` for cases where platform height is under 0.6m or invalid (<= 0)
- This prevents type errors and aligns with expected Float return types

### Tests
- Added new specs in `slide_calculator_spec.rb` and `en14960_spec.rb` to verify:
  - Return value is `0.0` (Float) for platform heights under 0.6m
  - Correct breakdown messages indicating no walls are required

### Versioning
- Bumped version from `0.4.0` to `0.4.1`
- Updated changelog with details of the fix

## Test plan
- Run all existing and new RSpec tests to ensure no regressions
- Confirm that the new edge case tests pass successfully
- Validate that the return type is consistently Float for no wall requirements scenarios

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6016f212-6565-460c-971c-1ed6b9766daf